### PR TITLE
Image render vita

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -17,13 +17,13 @@ class MediaAdminController extends Controller
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws AccessDeniedException
      */
-    public function browserAction()
+    public function browserAction(Request $request = null)
     {
         if (false === $this->admin->isGranted('LIST')) {
             throw new AccessDeniedException();
         }
 
-        $linkTo = $this->getRequest()->query->get('linkTo', 'page');
+        $linkTo = $request->query->get('linkTo', 'page');
 
         // params for both templates
         $tplName = null;
@@ -35,7 +35,7 @@ class MediaAdminController extends Controller
 
         // page link
         if ($linkTo == 'page') {
-            $pageList =  $this->loadPageList();
+            $pageList =  $this->loadPageList($request->getLocale());
 
             // set template values
             $tplName = 'SymbioOrangeGateMediaBundle:MediaAdmin:pages.html.twig';
@@ -152,13 +152,12 @@ class MediaAdminController extends Controller
     }
 
 
-    public function uploadAction()
+    public function uploadAction(Request $request = null)
     {
         if (false === $this->admin->isGranted('CREATE')) {
             throw new AccessDeniedException();
         }
         $mediaManager = $this->get('sonata.media.manager.media');
-        $request = $this->getRequest();
         $provider = $request->get('provider');
         $file = $request->files->get('upload');
         if (!$request->isMethod('POST') || !$provider || null === $file) {
@@ -179,7 +178,7 @@ class MediaAdminController extends Controller
      * Loads lists of pages available that user can links to
      * @return array
      */
-    protected function loadPageList() {
+    protected function loadPageList($locale) {
         $list = $this->get('doctrine')->getManager()->createQuery("
 			SELECT
 				p
@@ -195,7 +194,7 @@ class MediaAdminController extends Controller
 		  	ORDER BY
 		  		p.position
 		")
-            ->setParameter('locale', $this->getRequest()->getLocale())
+            ->setParameter('locale', $locale)
             ->setParameter('enabled', true)
             ->getResult()
         ;

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Symbio\OrangeGate\MediaBundle\Controller;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Sonata\MediaBundle\Controller\MediaController as Controller;
+use Symfony\Component\HttpFoundation\Response;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
+class MediaController extends Controller
+{
+	/**
+	 * @Route("/orangegate/media/show/{id}/{format}", name="orangegate_media_show")
+	 *
+	 * @throws NotFoundHttpException
+	 *
+	 * @param string $id
+	 * @param string $format
+	 *
+	 * @return Response
+	 */
+	public function showAction($id, $format = 'reference')
+	{
+		$media = $this->getMedia($id);
+
+		if (!$media) {
+			throw new NotFoundHttpException(sprintf('unable to find the media with the id : %s', $id));
+		}
+
+		$provider = $this->get($media->getProviderName());
+
+		if ($format == 'reference') {
+			$file = $provider->getReferenceFile($media);
+		} else {
+			$file = $provider->getFilesystem()->get($provider->generatePrivateUrl($media, $format));
+		}
+
+		$filePath = sprintf('%s/%s',
+			$provider->getFilesystem()->getAdapter()->getDirectory(),
+			$file->getKey()
+		);
+
+		if (!$file || !file_exists($filePath)) {
+			throw new NotFoundHttpException(sprintf('file not exists : %s', $file->getKey()));
+		}
+
+		$response = new StreamedResponse(function() use ($file) {
+			echo $file->getContent();
+		}, Response::HTTP_OK, array(
+			'Content-Type'          => $media->getContentType(),
+			'Content-Disposition'   => sprintf('inline; filename="%s"', $media->getMetadataValue('filename')),
+
+		));
+
+		$response->setPrivate();
+		$response->headers->addCacheControlDirective('max-age', 0);
+		$response->headers->addCacheControlDirective('no-cache', true);
+		$response->headers->addCacheControlDirective('no-store', true);
+		$response->headers->addCacheControlDirective('must-revalidate', true);
+
+		return $response;
+	}
+}

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -10,7 +10,7 @@ use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\AdminBundle\Form\FormMapper;
-use \Sonata\MediaBundle\Provider\FileProvider as BaseFileProvider;
+use Sonata\MediaBundle\Provider\FileProvider as BaseFileProvider;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;

--- a/Provider/ImageProvider.php
+++ b/Provider/ImageProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symbio\OrangeGate\MediaBundle\Provider;
+
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\ImageProvider as BaseImageProvider;
+
+class ImageProvider extends BaseImageProvider
+{
+	/**
+	 * Generate reference thumbnail beside common thumbnails
+	 *
+	 * {@inheritdoc}
+	 */
+	public function generateThumbnails(MediaInterface $media)
+	{
+		$this->generateReferenceThumbnail($media);
+		$this->thumbnail->generate($this, $media);
+	}
+
+	/**
+	 * Store reference thumbnail - filename e.g. thumb_007_reference.jpeg
+	 *
+	 * @param MediaInterface $media
+	 */
+	public function generateReferenceThumbnail(MediaInterface $media)
+	{
+		$in = $this->getReferenceFile($media);
+		$out = $this->getFilesystem()->get($this->generatePrivateUrl($media, 'reference'), true);
+		$out->setContent($in->getContent());
+	}
+
+	/**
+	 * Return reference thumbnail path if exists, otherwise return common reference path
+	 *
+	 * {@inheritdoc}
+	 */
+	public function getReferenceImage(MediaInterface $media)
+	{
+		$thumbMediaPath = $this->thumbnail->generatePrivateUrl($this, $media, 'reference');
+		if (file_exists($this->getFilesystem()->getAdapter()->getDirectory() . '/' . $thumbMediaPath)) {
+			return $thumbMediaPath;
+		} else {
+			return sprintf('%s/%s',
+				$this->generatePath($media),
+				$media->getProviderReference()
+			);
+		}
+	}
+}

--- a/Resources/config/provider.yml
+++ b/Resources/config/provider.yml
@@ -1,5 +1,6 @@
 parameters:
     sonata.media.provider.file.class: Symbio\OrangeGate\MediaBundle\Provider\FileProvider
+    sonata.media.provider.image.class: Symbio\OrangeGate\MediaBundle\Provider\ImageProvider
 #    sonata.media.provider.file.class: Symbio\OrangeGate\MediaBundle\Provider\DownloadProvider
 
 services:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,3 +28,13 @@ services:
       class: Symbio\OrangeGate\MediaBundle\Uploader\ErrorHandler\UploaderErrorHandler
       arguments: [ @translator ]
 
+    orangegate.media.twig.extension:
+        class: Symbio\OrangeGate\MediaBundle\Twig\Extension\MediaExtension
+        arguments: [@sonata.media.pool, @sonata.media.manager.media, @router]
+        tags:
+            - { name: twig.extension }
+
+    orangegate.media.formatter.twig:
+        class: Symbio\OrangeGate\MediaBundle\Twig\Extension\FormatterMediaExtension
+        arguments: [@orangegate.media.twig.extension]
+

--- a/Resources/views/MediaAdmin/browser.html.twig
+++ b/Resources/views/MediaAdmin/browser.html.twig
@@ -88,11 +88,9 @@
                                 {% elseif field_description.name == 'name' %}
                                     <td>
                                         <div>
-                                                <a href="{% path object, 'reference' %}" class="select" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
-
-                                                <strong><a href="{% path object, 'reference' %}" class="select">{{ object.name }}</a></strong> <br />
+                                            <a href="{{ path('orangegate_media_show', {'id': object.id}) }}" class="select" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75} %}</a>
+                                            <strong><a href="{{ path('orangegate_media_show', {'id': object.id}) }}" class="select">{{ object.name }}</a></strong> <br />
                                             {{ object.providerName|trans({}, 'SonataMediaBundle') }}{% if object.width %}: {{ object.width }}{% if object.height %}x{{ object.height }}{% endif %}px{% endif %}
-
                                             {% if formats[object.id]|length > 0 %}
                                                 - {{ 'title.formats'|trans({}, 'SonataMediaBundle') }}:
                                                 {% for name, format in formats[object.id] %}

--- a/Twig/Extension/FormatterMediaExtension.php
+++ b/Twig/Extension/FormatterMediaExtension.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Symbio\OrangeGate\MediaBundle\Twig\Extension;
+
+use Sonata\FormatterBundle\Extension\BaseProxyExtension;
+use Symbio\OrangeGate\MediaBundle\Twig\TokenParser\PathTokenParser;
+
+class FormatterMediaExtension extends BaseProxyExtension
+{
+    protected $twigExtension;
+
+    /**
+     * @param \Twig_Extension $twigExtension
+     */
+    public function __construct(\Twig_Extension $twigExtension)
+    {
+        $this->twigExtension = $twigExtension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedTags()
+    {
+        return array(
+            'og_path',
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedMethods()
+    {
+        return array(
+            'Sonata\MediaBundle\Model\MediaInterface' => array(
+                'getproviderreference'
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTokenParsers()
+    {
+        return array(
+            new PathTokenParser($this->getName()),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTwigExtension()
+    {
+        return $this->twigExtension;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'orangegate_formatter_media';
+    }
+
+    /**
+     * @param integer $media
+     * @param string  $format
+     *
+     * @return string
+     */
+    public function path($media = null, $format)
+    {
+        return $this->getTwigExtension()->path($media, $format);
+    }
+}

--- a/Twig/Extension/MediaExtension.php
+++ b/Twig/Extension/MediaExtension.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Symbio\OrangeGate\MediaBundle\Twig\Extension;
+
+use Symbio\OrangeGate\MediaBundle\Twig\TokenParser\PathTokenParser;
+use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\Pool;
+
+class MediaExtension extends \Twig_Extension
+{
+    protected $resources = array();
+
+    protected $mediaManager;
+    protected $mediaService;
+
+    protected $router;
+
+    protected $environment;
+
+    /**
+     * @param Pool             $mediaService
+     * @param ManagerInterface $mediaManager
+     */
+    public function __construct(Pool $mediaService, ManagerInterface $mediaManager, $router)
+    {
+        $this->mediaService = $mediaService;
+        $this->mediaManager = $mediaManager;
+        $this->router = $router;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTokenParsers()
+    {
+        return array(
+            new PathTokenParser($this->getName()),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('og_image', array($this, 'imageFilter')),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initRuntime(\Twig_Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @param mixed $media
+     *
+     * @return null|\Sonata\MediaBundle\Model\MediaInterface
+     */
+    private function getMedia($media)
+    {
+        if (!$media instanceof MediaInterface && strlen($media) > 0) {
+            $media = $this->mediaManager->findOneBy(array(
+                'id' => $media
+            ));
+        }
+
+        if (!$media instanceof MediaInterface) {
+            return false;
+        }
+
+        if ($media->getProviderStatus() !== MediaInterface::STATUS_OK) {
+            return false;
+        }
+
+        return $media;
+    }
+
+    /**
+     * @return \Sonata\MediaBundle\Provider\Pool
+     */
+    public function getMediaService()
+    {
+        return $this->mediaService;
+    }
+
+    /**
+     * @param \Sonata\MediaBundle\Model\MediaInterface $media
+     * @param string                                   $format
+     *
+     * @return string
+     */
+    public function path($media = null, $format)
+    {
+        $media = $this->getMedia($media);
+
+        if (!$media) {
+             return '';
+        }
+
+        $provider = $this->getMediaService()
+           ->getProvider($media->getProviderName());
+
+        $format = $provider->getFormatName($media, $format);
+
+        return $provider->generatePublicUrl($media, $format).'?'.$media->getUpdatedAt()->getTimestamp();
+    }
+
+    /**
+     * Return block translation by key.
+     *
+     * @param string $content
+     * @return string
+     */
+    public function imageFilter($content)
+    {
+        $temporaryImageUrl = substr($this->router->generate('orangegate_media_show', array('id' => 1)),0,-1);
+        return preg_replace_callback(
+            '|'.$temporaryImageUrl.'(\d+)(/(.+)([\'"]))?|',
+            function ($matches) {
+                return $this->path($matches[1], isset($matches[3]) && $matches[3] ? $matches[3] : 'reference').(isset($matches[4]) && $matches[4] ? $matches[4] : '');
+            },
+            $content
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'orangegate_media';
+    }
+}

--- a/Twig/Node/PathNode.php
+++ b/Twig/Node/PathNode.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of sonata-project.
+ *
+ * (c) 2010 Thomas Rabaix
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symbio\OrangeGate\MediaBundle\Twig\Node;
+
+class PathNode extends \Twig_Node
+{
+    protected $extensionName;
+
+    /**
+     * @param array                 $extensionName
+     * @param \Twig_Node_Expression $media
+     * @param \Twig_Node_Expression $format
+     * @param integer               $lineno
+     * @param string                $tag
+     */
+    public function __construct($extensionName, \Twig_Node_Expression $media, \Twig_Node_Expression $format, $lineno, $tag = null)
+    {
+        $this->extensionName = $extensionName;
+
+        parent::__construct(array('media' => $media, 'format' => $format), array(), $lineno, $tag);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write(sprintf("echo \$this->env->getExtension('%s')->path(", $this->extensionName))
+            ->subcompile($this->getNode('media'))
+            ->raw(', ')
+            ->subcompile($this->getNode('format'))
+            ->raw(");\n")
+        ;
+    }
+}

--- a/Twig/TokenParser/PathTokenParser.php
+++ b/Twig/TokenParser/PathTokenParser.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of sonata-project.
+ *
+ * (c) 2010 Thomas Rabaix
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symbio\OrangeGate\MediaBundle\Twig\TokenParser;
+
+use Symbio\OrangeGate\MediaBundle\Twig\Node\PathNode;
+
+class PathTokenParser extends \Twig_TokenParser
+{
+    protected $extensionName;
+
+    /**
+     * @param string $extensionName
+     */
+    public function __construct($extensionName)
+    {
+        $this->extensionName = $extensionName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $media = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->next();
+
+        $format = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new PathNode($this->extensionName, $media, $format, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag()
+    {
+        return 'og_path';
+    }
+}


### PR DESCRIPTION
- added image show action in media controller
- new twig extension
  - function `og_path` - inserts timestamp in parameteres as well
  - filter `og_image` - replaces show action to the reference path

**BC break: add new route**

``` YAML
    orangegate_media:
        resource: "@SymbioOrangeGateMediaBundle/Controller/MediaController.php"
        type: annotation
```
