### PR TITLE
set thumbnail umask to 664

### DIFF
--- a/Provider/ImageProvider.php
+++ b/Provider/ImageProvider.php
@@ -27,7 +27,9 @@ class ImageProvider extends BaseImageProvider
 	{
 		$in = $this->getReferenceFile($media);
 		$out = $this->getFilesystem()->get($this->generatePrivateUrl($media, 'reference'), true);
+		$oldUmask = umask(0002);
 		$out->setContent($in->getContent());
+		umask($oldUmask);
 	}
 
 	/**

--- a/Thumbnail/FormatThumbnail.php
+++ b/Thumbnail/FormatThumbnail.php
@@ -62,6 +62,7 @@ class FormatThumbnail implements ThumbnailInterface
 
         foreach ($provider->getFormats() as $format => $settings) {
             if (substr($format, 0, strlen($media->getContext())) == $media->getContext() || $format === 'admin' || $format == 'orangegate') {
+                $oldUmask = umask(0002);
                 $provider->getResizer()->resize(
                     $media,
                     $referenceFile,
@@ -69,6 +70,7 @@ class FormatThumbnail implements ThumbnailInterface
                     $this->getExtension($media),
                     $settings
                 );
+                umask($oldUmask);
             }
         }
     }


### PR DESCRIPTION
Sets umask during thumbnail generating to **664**.

The problem starts within using sync-thumbnails command which sets thumbnail file owner as logged user, specifically _symbioftp:www-data_ with rights **644**. Next image update bring fatal error when app try to remove thumbnail.  
