### PR TITLE
Generate relative url (without host) instead absolute url

### DIFF
--- a/Resources/views/CRUD/edit_orm_media_association_script.html.twig
+++ b/Resources/views/CRUD/edit_orm_media_association_script.html.twig
@@ -213,7 +213,7 @@
         jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
         jQuery.ajax({
             type: 'GET',
-            url: '{{ url('sonata_admin_short_object_information', {
+            url: '{{ path('sonata_admin_short_object_information', {
                 'objectId': 'OBJECT_ID',
                 'uniqid': associationadmin.uniqid,
                 'code': media_admin.code,

--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -12,7 +12,7 @@
             <li>
                 <div class="sonata-tree__item{% if element.id == current_category %} is-active{% endif %} is-toggled" data-treeview-toggled>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
-                    <a class="sonata-tree__item__edit" href="{{ url(app.request.attributes.get('_route'), app.request.query.all|merge({category: element.id})) }}">{{ element.name }}</a>
+                    <a class="sonata-tree__item__edit" href="{{ path(app.request.attributes.get('_route'), app.request.query.all|merge({category: element.id})) }}">{{ element.name }}</a>
                 </div>
 
                 {% if element.children|length %}


### PR DESCRIPTION
Replaced "url" with "path" in twig templates.

Problem was that in development environment URLs generated by url
function were pointing to production instance when site entity property
"host" was set to production host name. This was causing confusion when
using certain links on different than production environment.
