### PR TITLE
Timestamp on media file URL

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -159,7 +159,7 @@
             <span id="field_widget_{{ id }}" class="field-short-description">
                 <a class="btn btn-xs btn-danger image-box-close" href="#"><i class="fa fa-2x fa-trash"></i></a>
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {% thumbnail sonata_admin.value, 'orangegate' %}
+                    {% og_thumbnail sonata_admin.value, 'orangegate' %}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/MediaAdmin/browser.html.twig
+++ b/Resources/views/MediaAdmin/browser.html.twig
@@ -119,7 +119,7 @@
                                 {% elseif field_description.name == 'name' %}
                                     <td>
                                         <div>
-                                            <a href="{{ path('orangegate_media_show', {'id': object.id}) }}" class="select" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75} %}</a>
+                                            <a href="{{ path('orangegate_media_show', {'id': object.id}) }}" class="select" style="float: left; margin-right: 6px;">{% og_thumbnail object, 'admin' with {'width': 75} %}</a>
                                             <strong><a href="{{ path('orangegate_media_show', {'id': object.id}) }}" class="select">{{ object.name }}</a></strong> <br />
                                             {{ object.providerName|trans({}, 'SonataMediaBundle') }}{% if object.width %}: {{ object.width }}{% if object.height %}x{{ object.height }}{% endif %}px{% endif %}
                                             {% if formats[object.id]|length > 0 %}

--- a/Resources/views/MediaAdmin/edit.html.twig
+++ b/Resources/views/MediaAdmin/edit.html.twig
@@ -34,7 +34,7 @@
                         <div class="box-body table-responsive">
 
                             <center style="margin-bottom:20px"> <!-- yeah, center is still awesome ;) -->
-                                {% media object, 'reference' with {'width': null, 'height': null, 'class': 'img-responsive img-rounded'} %}
+                                {% og_media object, 'reference' with {'width': null, 'height': null, 'class': 'img-responsive img-rounded'} %}
                             </center>
 
                             <table class="table">

--- a/Resources/views/MediaAdmin/inner_row_media.html.twig
+++ b/Resources/views/MediaAdmin/inner_row_media.html.twig
@@ -16,9 +16,9 @@ file that was distributed with this source code.
 		{% if (object.providerName == 'sonata.media.provider.image') %}
 			<div class="pull-left">
 				{% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
-					<a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' %}</a>
+					<a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}" style="float: left; margin-right: 6px;">{% og_thumbnail object, 'admin' %}</a>
 				{% else %}
-					{% thumbnail object, 'admin' %}
+					{% og_thumbnail object, 'admin' %}
 				{% endif %}
 			</div>
 		{% endif %}

--- a/Twig/Extension/FormatterMediaExtension.php
+++ b/Twig/Extension/FormatterMediaExtension.php
@@ -4,6 +4,8 @@ namespace Symbio\OrangeGate\MediaBundle\Twig\Extension;
 
 use Sonata\FormatterBundle\Extension\BaseProxyExtension;
 use Symbio\OrangeGate\MediaBundle\Twig\TokenParser\PathTokenParser;
+use Symbio\OrangeGate\MediaBundle\Twig\TokenParser\MediaTokenParser;
+use Symbio\OrangeGate\MediaBundle\Twig\TokenParser\ThumbnailTokenParser;
 
 class FormatterMediaExtension extends BaseProxyExtension
 {
@@ -24,6 +26,8 @@ class FormatterMediaExtension extends BaseProxyExtension
     {
         return array(
             'og_path',
+            'og_media',
+            'og_thumbnail',
         );
     }
 
@@ -46,6 +50,8 @@ class FormatterMediaExtension extends BaseProxyExtension
     {
         return array(
             new PathTokenParser($this->getName()),
+            new MediaTokenParser($this->getName()),
+            new ThumbnailTokenParser($this->getName()),
         );
     }
 

--- a/Twig/TokenParser/MediaTokenParser.php
+++ b/Twig/TokenParser/MediaTokenParser.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of sonata-project.
+ *
+ * (c) 2010 Thomas Rabaix
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symbio\OrangeGate\MediaBundle\Twig\TokenParser;
+
+use Sonata\MediaBundle\Twig\Node\MediaNode;
+
+class MediaTokenParser extends \Twig_TokenParser
+{
+    protected $extensionName;
+
+    /**
+     * @param string $extensionName
+     */
+    public function __construct($extensionName)
+    {
+        $this->extensionName = $extensionName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $media = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->next();
+
+        $format = $this->parser->getExpressionParser()->parseExpression();
+
+        // attributes
+        if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'with')) {
+            $this->parser->getStream()->next();
+
+            $attributes = $this->parser->getExpressionParser()->parseExpression();
+        } else {
+            $attributes = new \Twig_Node_Expression_Array(array(), $token->getLine());
+        }
+
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new MediaNode($this->extensionName, $media, $format, $attributes, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag()
+    {
+        return 'og_media';
+    }
+}

--- a/Twig/TokenParser/ThumbnailTokenParser.php
+++ b/Twig/TokenParser/ThumbnailTokenParser.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of sonata-project.
+ *
+ * (c) 2010 Thomas Rabaix
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symbio\OrangeGate\MediaBundle\Twig\TokenParser;
+
+use Sonata\MediaBundle\Twig\Node\ThumbnailNode;
+
+class ThumbnailTokenParser extends \Twig_TokenParser
+{
+    protected $extensionName;
+
+    /**
+     * @param string $extensionName
+     */
+    public function __construct($extensionName)
+    {
+        $this->extensionName = $extensionName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $media = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->next();
+
+        $format = $this->parser->getExpressionParser()->parseExpression();
+
+        // attributes
+        if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'with')) {
+            $this->parser->getStream()->next();
+
+            $attributes = $this->parser->getExpressionParser()->parseExpression();
+        } else {
+            $attributes = new \Twig_Node_Expression_Array(array(), $token->getLine());
+        }
+
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new ThumbnailNode($this->extensionName, $media, $format, $attributes, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag()
+    {
+        return 'og_thumbnail';
+    }
+}


### PR DESCRIPTION
New tags og_media and og_thumbnail that add file timestamp to generaed url.

Allows to evade browser cache on media file change.
